### PR TITLE
Add support for usage of JsonObjects and JsonArrays on REST endpoints

### DIFF
--- a/examples/jackson/pom.xml
+++ b/examples/jackson/pom.xml
@@ -12,13 +12,13 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.glassfish.jersey.media</groupId>
-            <artifactId>jersey-media-json-jackson</artifactId>
-            <version>${jersey.version}</version>
+            <groupId>com.englishtown.vertx</groupId>
+            <artifactId>vertx-hk2</artifactId>
         </dependency>
         <dependency>
             <groupId>com.englishtown.vertx</groupId>
-            <artifactId>vertx-hk2</artifactId>
+            <artifactId>vertx-jersey-jackson</artifactId>
+            <version>${project.version}</version>
         </dependency>
     </dependencies>
 

--- a/examples/jackson/src/main/java/com/englishtown/vertx/jersey/examples/resources/JsonResource.java
+++ b/examples/jackson/src/main/java/com/englishtown/vertx/jersey/examples/resources/JsonResource.java
@@ -1,6 +1,9 @@
 package com.englishtown.vertx.jersey.examples.resources;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import org.glassfish.jersey.server.JSONP;
 
 import javax.ws.rs.*;
@@ -37,6 +40,22 @@ public class JsonResource {
         return in;
     }
 
+    @POST
+    @Path("json_object")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObjectWrapper postJsonObject(JsonObjectWrapper in) {
+        return in;
+    }
+
+    @POST
+    @Path("json_array")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonArrayWrapper postJsonArray(JsonArrayWrapper in) {
+        return in;
+    }
+
     @GET
     @Path("async")
     @Produces(MediaType.APPLICATION_JSON)
@@ -58,6 +77,32 @@ public class JsonResource {
 
         public void setName(String name) {
             this.name = name;
+        }
+    }
+
+    public static class JsonObjectWrapper {
+
+        private JsonObject metadata;
+
+        public JsonObject getMetadata() {
+            return metadata;
+        }
+
+        public void setMetadata(JsonObject metadata) {
+            this.metadata = metadata;
+        }
+    }
+
+    public static class JsonArrayWrapper {
+
+        private JsonArray groupIds;
+
+        public JsonArray getGroupIds() {
+            return groupIds;
+        }
+
+        public void setGroupIds(JsonArray groupIds) {
+            this.groupIds = groupIds;
         }
     }
 

--- a/examples/jackson/src/test/java/com/englishtown/vertx/jersey/examples/integration/JacksonIntegrationTest.java
+++ b/examples/jackson/src/test/java/com/englishtown/vertx/jersey/examples/integration/JacksonIntegrationTest.java
@@ -5,10 +5,12 @@ import com.englishtown.vertx.promises.RequestOptions;
 import io.vertx.core.buffer.Buffer;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import org.junit.Test;
 
 import javax.ws.rs.core.MediaType;
+import java.util.Date;
 import java.util.function.Consumer;
 
 public class JacksonIntegrationTest extends JerseyHK2IntegrationTestBase {
@@ -63,6 +65,64 @@ public class JacksonIntegrationTest extends JerseyHK2IntegrationTestBase {
                 .then(body -> {
                     JsonObject json = new JsonObject(body.toString());
                     assertEquals("Andy", json.getString("name"));
+                    testComplete();
+                    return null;
+                })
+                .otherwise(this::onRejected);
+
+        await();
+
+    }
+
+    @Test
+    public void testPostJsonObject() throws Exception {
+
+        Date now = new Date();
+
+        RequestOptions options = new RequestOptions()
+                .setPauseResponse(true)
+                .setSetupHandler(request -> {
+                    request.putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+                    return null;
+                })
+                .setData(new JsonObject().put("metadata", new JsonObject().put("created", now.toString())).encode());
+
+        whenHttpClient.requestAbs(HttpMethod.POST, BASE_PATH + "/json_object", options)
+                .then(response -> {
+                    assertEquals(200, response.statusCode());
+                    return whenHttpClient.body(response);
+                })
+                .then(body -> {
+                    JsonObject json = new JsonObject(body.toString());
+                    assertEquals(now.toString(), json.getJsonObject("metadata").getString("created"));
+                    testComplete();
+                    return null;
+                })
+                .otherwise(this::onRejected);
+
+        await();
+
+    }
+
+    @Test
+    public void testPostJsonArray() throws Exception {
+
+        RequestOptions options = new RequestOptions()
+                .setPauseResponse(true)
+                .setSetupHandler(request -> {
+                    request.putHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+                    return null;
+                })
+                .setData(new JsonObject().put("groupIds", new JsonArray().add(4).add(8)).encode());
+
+        whenHttpClient.requestAbs(HttpMethod.POST, BASE_PATH + "/json_array", options)
+                .then(response -> {
+                    assertEquals(200, response.statusCode());
+                    return whenHttpClient.body(response);
+                })
+                .then(body -> {
+                    JsonObject json = new JsonObject(body.toString());
+                    assertEquals("{\"groupIds\":[4,8]}", json.toString());
                     testComplete();
                     return null;
                 })

--- a/examples/jackson/src/test/resources/config.json
+++ b/examples/jackson/src/test/resources/config.json
@@ -2,6 +2,5 @@
     "host": "localhost",
     "port": 8080,
     "base_path": "/",
-    "resources": ["com.englishtown.vertx.jersey.examples.resources"],
-    "features": ["org.glassfish.jersey.jackson.JacksonFeature"]
+    "resources": ["com.englishtown.vertx.jersey.examples.resources"]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <module>vertx-jersey</module>
         <module>vertx-jersey-metrics</module>
         <module>examples</module>
+        <module>vertx-jersey-jackson</module>
     </modules>
 
     <properties>

--- a/vertx-jersey-jackson/pom.xml
+++ b/vertx-jersey-jackson/pom.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>vertx-jersey-parent</artifactId>
+        <groupId>com.englishtown.vertx</groupId>
+        <version>4.1.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>vertx-jersey-jackson</artifactId>
+
+    <properties>
+        <vertx.jersey.version>4.1.0-SNAPSHOT</vertx.jersey.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.glassfish.jersey.media</groupId>
+            <artifactId>jersey-media-json-jackson</artifactId>
+            <version>${jersey.version}</version>
+        </dependency>
+
+        <!-- Test Dependencies !-->
+        <dependency>
+            <groupId>com.englishtown.vertx</groupId>
+            <artifactId>vertx-jersey</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vertx</groupId>
+            <artifactId>vertx-core</artifactId>
+            <version>${vertx.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.englishtown.vertx</groupId>
+            <artifactId>vertx-jersey</artifactId>
+            <version>${project.version}</version>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.englishtown.vertx</groupId>
+            <artifactId>vertx-hk2</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.englishtown</groupId>
+            <artifactId>when.java</artifactId>
+            <type>test-jar</type>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.englishtown.vertx</groupId>
+            <artifactId>vertx-when</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/vertx-jersey-jackson/src/main/java/com/englishtown/vertx/jersey/jackson/JsonObjectFeature.java
+++ b/vertx-jersey-jackson/src/main/java/com/englishtown/vertx/jersey/jackson/JsonObjectFeature.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.jackson;
+
+import com.englishtown.vertx.jersey.jackson.internal.DefaultObjectMapperConfigurator;
+import com.englishtown.vertx.jersey.jackson.internal.JsonObjectMapperProvider;
+import org.glassfish.hk2.utilities.binding.AbstractBinder;
+
+import javax.inject.Singleton;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * Feature used to register JsonObject serializers and deserializers for Jackson.
+ */
+public class JsonObjectFeature implements Feature {
+
+    @Override
+    public boolean configure(final FeatureContext context) {
+
+        if(!context.getConfiguration().isRegistered(JsonObjectMapperProvider.class)) {
+            context.register(new Binder());
+            context.register(JsonObjectMapperProvider.class);
+        }
+
+        return true;
+
+    }
+
+    private static class Binder extends AbstractBinder {
+        @Override
+        protected void configure() {
+            bind(DefaultObjectMapperConfigurator.class).to(ObjectMapperConfigurator.class).in(Singleton.class);
+        }
+    }
+
+
+}

--- a/vertx-jersey-jackson/src/main/java/com/englishtown/vertx/jersey/jackson/ObjectMapperConfigurator.java
+++ b/vertx-jersey-jackson/src/main/java/com/englishtown/vertx/jersey/jackson/ObjectMapperConfigurator.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.jackson;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+/**
+ * A configurator for {@link ObjectMapper} objects, used to set the behavior of the ObjectMapper provided by
+ * {@link com.englishtown.vertx.jersey.jackson.internal.JsonObjectMapperProvider}.
+ */
+public interface ObjectMapperConfigurator {
+
+    /**
+     * Configures the provided {@link ObjectMapper}.
+     * @param mapper The ObjectMapper to be configured.
+     */
+    void configure(ObjectMapper mapper);
+
+}

--- a/vertx-jersey-jackson/src/main/java/com/englishtown/vertx/jersey/jackson/internal/DefaultObjectMapperConfigurator.java
+++ b/vertx-jersey-jackson/src/main/java/com/englishtown/vertx/jersey/jackson/internal/DefaultObjectMapperConfigurator.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.jackson.internal;
+
+import com.englishtown.vertx.jersey.jackson.ObjectMapperConfigurator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import javax.ws.rs.ext.Provider;
+
+/**
+ * This is a no-op {@link ObjectMapperConfigurator} used as a default implementation.
+ */
+@Provider
+public class DefaultObjectMapperConfigurator implements ObjectMapperConfigurator {
+
+    @Override
+    public void configure(ObjectMapper mapper) { }
+
+}

--- a/vertx-jersey-jackson/src/main/java/com/englishtown/vertx/jersey/jackson/internal/JsonArrayDeserializer.java
+++ b/vertx-jersey-jackson/src/main/java/com/englishtown/vertx/jersey/jackson/internal/JsonArrayDeserializer.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.jackson.internal;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import io.vertx.core.json.JsonArray;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+/**
+ * A custom deserializer for Jackson to deserialize {@link JsonArray}s.
+ */
+public class JsonArrayDeserializer extends JsonDeserializer<JsonArray> {
+
+    private static final TypeReference<ArrayList<Object>> jsonArrayType =
+            new TypeReference<ArrayList<Object>>() {};
+
+    @Override
+    public JsonArray deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+
+        ArrayList<Object> values = p.readValueAs(jsonArrayType);
+        return new JsonArray(values);
+
+    }
+
+}

--- a/vertx-jersey-jackson/src/main/java/com/englishtown/vertx/jersey/jackson/internal/JsonArraySerializer.java
+++ b/vertx-jersey-jackson/src/main/java/com/englishtown/vertx/jersey/jackson/internal/JsonArraySerializer.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.jackson.internal;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import io.vertx.core.json.JsonArray;
+
+import java.io.IOException;
+
+/**
+ * A custom serializer for Jackson to serialize {@link JsonArray}s.
+ */
+public class JsonArraySerializer extends JsonSerializer<JsonArray> {
+
+    @Override
+    public void serialize(JsonArray value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeObject(value.getList());
+    }
+
+}

--- a/vertx-jersey-jackson/src/main/java/com/englishtown/vertx/jersey/jackson/internal/JsonObjectAutoDiscoverable.java
+++ b/vertx-jersey-jackson/src/main/java/com/englishtown/vertx/jersey/jackson/internal/JsonObjectAutoDiscoverable.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.jackson.internal;
+
+import com.englishtown.vertx.jersey.jackson.JsonObjectFeature;
+import org.glassfish.jersey.internal.spi.AutoDiscoverable;
+
+import javax.ws.rs.core.FeatureContext;
+
+/**
+ * {@link AutoDiscoverable} to register JsonObject parsers and serializers if not already registered.
+ */
+public class JsonObjectAutoDiscoverable implements AutoDiscoverable {
+
+    @Override
+    public void configure(FeatureContext context) {
+
+        if(!context.getConfiguration().isRegistered(JsonObjectFeature.class)) {
+            context.register(JsonObjectFeature.class);
+        }
+
+    }
+
+}

--- a/vertx-jersey-jackson/src/main/java/com/englishtown/vertx/jersey/jackson/internal/JsonObjectDeserializer.java
+++ b/vertx-jersey-jackson/src/main/java/com/englishtown/vertx/jersey/jackson/internal/JsonObjectDeserializer.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.jackson.internal;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import io.vertx.core.json.JsonObject;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+
+/**
+ * A custom deserializer for Jackson to deserialize {@link JsonObject}s.
+ */
+public class JsonObjectDeserializer extends JsonDeserializer<JsonObject> {
+
+    private static final TypeReference<LinkedHashMap<String, Object>> jsonObjectType =
+            new TypeReference<LinkedHashMap<String, Object>>() {};
+
+    @Override
+    public JsonObject deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+
+        LinkedHashMap<String, Object> values = p.readValueAs(jsonObjectType);
+        return new JsonObject(values);
+
+    }
+
+}

--- a/vertx-jersey-jackson/src/main/java/com/englishtown/vertx/jersey/jackson/internal/JsonObjectMapperProvider.java
+++ b/vertx-jersey-jackson/src/main/java/com/englishtown/vertx/jersey/jackson/internal/JsonObjectMapperProvider.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.jackson.internal;
+
+import com.englishtown.vertx.jersey.jackson.ObjectMapperConfigurator;
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+import javax.inject.Inject;
+import javax.ws.rs.ext.ContextResolver;
+
+/**
+ * A custom ContextResolver that returns a Jackson ObjectMapper that will automatically deserialize JsonObjects when
+ * appropriate.
+ */
+public class JsonObjectMapperProvider implements ContextResolver<ObjectMapper> {
+
+    private final ObjectMapper mapper;
+
+    @Inject
+    public JsonObjectMapperProvider(ObjectMapperConfigurator configurator) {
+
+        mapper = new ObjectMapper();
+
+        SimpleModule jsonObjectModule = new SimpleModule("JsonObjectDeserializerModule", Version.unknownVersion())
+            .addSerializer(JsonArray.class, new JsonArraySerializer())
+            .addSerializer(JsonObject.class, new JsonObjectSerializer())
+            .addDeserializer(JsonArray.class, new JsonArrayDeserializer())
+            .addDeserializer(JsonObject.class, new JsonObjectDeserializer());
+
+        mapper.registerModule(jsonObjectModule);
+
+        configurator.configure(mapper);
+
+    }
+
+    @Override
+    public ObjectMapper getContext(Class<?> type) {
+        return mapper;
+    }
+
+}

--- a/vertx-jersey-jackson/src/main/java/com/englishtown/vertx/jersey/jackson/internal/JsonObjectSerializer.java
+++ b/vertx-jersey-jackson/src/main/java/com/englishtown/vertx/jersey/jackson/internal/JsonObjectSerializer.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.jackson.internal;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import io.vertx.core.json.JsonObject;
+
+import java.io.IOException;
+
+/**
+ * A custom serializer for Jackson to serialize {@link JsonObject}s.
+ */
+public class JsonObjectSerializer extends JsonSerializer<JsonObject> {
+
+    @Override
+    public void serialize(JsonObject value, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        gen.writeObject(value.getMap());
+    }
+
+}

--- a/vertx-jersey-jackson/src/main/resources/META-INF/services/org.glassfish.jersey.internal.spi.AutoDiscoverable
+++ b/vertx-jersey-jackson/src/main/resources/META-INF/services/org.glassfish.jersey.internal.spi.AutoDiscoverable
@@ -1,0 +1,1 @@
+com.englishtown.vertx.jersey.jackson.internal.JsonObjectAutoDiscoverable

--- a/vertx-jersey-jackson/src/test/java/com/englishtown/vertx/jersey/integration/JsonArrayIntegrationTests.java
+++ b/vertx-jersey-jackson/src/test/java/com/englishtown/vertx/jersey/integration/JsonArrayIntegrationTests.java
@@ -1,0 +1,164 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.integration;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+import org.junit.Test;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Integration tests for {@link com.englishtown.vertx.jersey.jackson.internal.JsonArraySerializer} and
+ * {@link com.englishtown.vertx.jersey.jackson.internal.JsonArrayDeserializer}.
+ */
+public class JsonArrayIntegrationTests extends JerseyHK2IntegrationTestBase {
+
+    private static final String HOST = "localhost";
+    private static final int PORT = 8080;
+    public static final String ENDPOINT = "/rest/test/array";
+
+    private void verifyResponse(HttpClientResponse response, int status, String contentType, String expected) {
+
+        assertEquals(status, response.statusCode());
+        assertEquals(contentType, response.headers().get(HttpHeaders.CONTENT_TYPE));
+
+        if (expected != null) {
+            response.bodyHandler((Buffer body) -> {
+                String result = body.toString("UTF-8");
+                assertEquals(expected, result);
+                testComplete();
+            });
+        } else {
+            testComplete();
+        }
+    }
+
+    @Test
+    public void test_nullJsonArray() {
+
+        HttpClientRequest request = httpClient.request(HttpMethod.POST, PORT, HOST, ENDPOINT, response -> {
+            verifyResponse(response, 204, null, null);
+        });
+
+        request.headers().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        request.end("null");
+        await();
+
+    }
+
+    @Test
+    public void test_invalidJsonArray() {
+
+        String testJson = "{\"jsonArray\":[";
+
+        HttpClientRequest request = httpClient.request(HttpMethod.POST, PORT, HOST, ENDPOINT, response -> {
+            verifyResponse(response, 400, MediaType.TEXT_PLAIN, null);
+        });
+
+        request.headers().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        request.end(testJson);
+        await();
+
+    }
+
+    @Test
+    public void test_jsonObjectWhereArrayExpected() {
+
+        String testJson = "{\"jsonArray\":{}}";
+
+        HttpClientRequest request = httpClient.request(HttpMethod.POST, PORT, HOST, ENDPOINT, response -> {
+            verifyResponse(response, 400, MediaType.TEXT_PLAIN, null);
+        });
+
+        request.headers().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        request.end(testJson);
+        await();
+
+    }
+
+    @Test
+    public void test_jsonStringWhereArrayExpected() {
+
+        String testJson = "{\"jsonArray\":\"value\"}";
+
+        HttpClientRequest request = httpClient.request(HttpMethod.POST, PORT, HOST, ENDPOINT, response -> {
+            verifyResponse(response, 400, MediaType.TEXT_PLAIN, null);
+        });
+
+        request.headers().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        request.end(testJson);
+        await();
+
+    }
+
+    @Test
+    public void test_emptyJsonArray() {
+
+        String testJson = "{\"jsonArray\":[]}";
+
+        HttpClientRequest request = httpClient.request(HttpMethod.POST, PORT, HOST, ENDPOINT, response -> {
+            verifyResponse(response, 200, MediaType.APPLICATION_JSON, testJson);
+        });
+
+        request.headers().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        request.end(testJson);
+        await();
+
+    }
+
+    @Test
+    public void test_simpleJsonArray() {
+
+        String testJson = "{\"jsonArray\":[\"value\"]}";
+
+        HttpClientRequest request = httpClient.request(HttpMethod.POST, PORT, HOST, ENDPOINT, response -> {
+            verifyResponse(response, 200, MediaType.APPLICATION_JSON, testJson);
+        });
+
+        request.headers().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        request.end(testJson);
+        await();
+
+    }
+
+    @Test
+    public void test_complexJsonArray() {
+
+        String testJson = "{\"jsonArray\":[{\"key\":\"value\"}]}";
+
+        HttpClientRequest request = httpClient.request(HttpMethod.POST, PORT, HOST, ENDPOINT, response -> {
+            verifyResponse(response, 200, MediaType.APPLICATION_JSON, testJson);
+        });
+
+        request.headers().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        request.end(testJson);
+        await();
+
+    }
+
+}

--- a/vertx-jersey-jackson/src/test/java/com/englishtown/vertx/jersey/integration/JsonObjectIntegrationTests.java
+++ b/vertx-jersey-jackson/src/test/java/com/englishtown/vertx/jersey/integration/JsonObjectIntegrationTests.java
@@ -1,0 +1,164 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.integration;
+
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpClientRequest;
+import io.vertx.core.http.HttpClientResponse;
+import io.vertx.core.http.HttpMethod;
+import org.junit.Test;
+
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Integration tests for {@link com.englishtown.vertx.jersey.jackson.internal.JsonObjectSerializer} and
+ * {@link com.englishtown.vertx.jersey.jackson.internal.JsonObjectDeserializer}.
+ */
+public class JsonObjectIntegrationTests extends JerseyHK2IntegrationTestBase {
+
+    private static final String HOST = "localhost";
+    private static final int PORT = 8080;
+    public static final String ENDPOINT = "/rest/test/object";
+
+    private void verifyResponse(HttpClientResponse response, int status, String contentType, String expected) {
+
+        assertEquals(status, response.statusCode());
+        assertEquals(contentType, response.headers().get(HttpHeaders.CONTENT_TYPE));
+
+        if (expected != null) {
+            response.bodyHandler((Buffer body) -> {
+                String result = body.toString("UTF-8");
+                assertEquals(expected, result);
+                testComplete();
+            });
+        } else {
+            testComplete();
+        }
+    }
+
+    @Test
+    public void test_nullJsonObject() {
+
+        HttpClientRequest request = httpClient.request(HttpMethod.POST, PORT, HOST, ENDPOINT, response -> {
+            verifyResponse(response, 204, null, null);
+        });
+
+        request.headers().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        request.end("null");
+        await();
+
+    }
+
+    @Test
+    public void test_invalidJsonObject() {
+
+        String testJson = "{\"jsonObject\":{";
+
+        HttpClientRequest request = httpClient.request(HttpMethod.POST, PORT, HOST, ENDPOINT, response -> {
+            verifyResponse(response, 400, MediaType.TEXT_PLAIN, null);
+        });
+
+        request.headers().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        request.end(testJson);
+        await();
+
+    }
+
+    @Test
+    public void test_jsonArrayWhereObjectExpected() {
+
+        String testJson = "{\"jsonObject\":[]}";
+
+        HttpClientRequest request = httpClient.request(HttpMethod.POST, PORT, HOST, ENDPOINT, response -> {
+            verifyResponse(response, 400, MediaType.TEXT_PLAIN, null);
+        });
+
+        request.headers().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        request.end(testJson);
+        await();
+
+    }
+
+    @Test
+    public void test_jsonStringWhereObjectExpected() {
+
+        String testJson = "{\"jsonObject\":\"value\"}";
+
+        HttpClientRequest request = httpClient.request(HttpMethod.POST, PORT, HOST, ENDPOINT, response -> {
+            verifyResponse(response, 400, MediaType.TEXT_PLAIN, null);
+        });
+
+        request.headers().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        request.end(testJson);
+        await();
+
+    }
+
+    @Test
+    public void test_emptyJsonObject() {
+
+        String testJson = "{\"jsonObject\":{}}";
+
+        HttpClientRequest request = httpClient.request(HttpMethod.POST, PORT, HOST, ENDPOINT, response -> {
+            verifyResponse(response, 200, MediaType.APPLICATION_JSON, testJson);
+        });
+
+        request.headers().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        request.end(testJson);
+        await();
+
+    }
+
+    @Test
+    public void test_simpleJsonObject() {
+
+        String testJson = "{\"jsonObject\":{\"key\":\"value\"}}";
+
+        HttpClientRequest request = httpClient.request(HttpMethod.POST, PORT, HOST, ENDPOINT, response -> {
+            verifyResponse(response, 200, MediaType.APPLICATION_JSON, testJson);
+        });
+
+        request.headers().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        request.end(testJson);
+        await();
+
+    }
+
+    @Test
+    public void test_complexJsonObject() {
+
+        String testJson = "{\"jsonObject\":{\"innerObject\":{\"key\":\"value\"}}}";
+
+        HttpClientRequest request = httpClient.request(HttpMethod.POST, PORT, HOST, ENDPOINT, response -> {
+            verifyResponse(response, 200, MediaType.APPLICATION_JSON, testJson);
+        });
+
+        request.headers().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        request.end(testJson);
+        await();
+
+    }
+
+}

--- a/vertx-jersey-jackson/src/test/java/com/englishtown/vertx/jersey/jackson/internal/JsonArrayDeserializerTest.java
+++ b/vertx-jersey-jackson/src/test/java/com/englishtown/vertx/jersey/jackson/internal/JsonArrayDeserializerTest.java
@@ -1,0 +1,91 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.jackson.internal;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import io.vertx.core.json.JsonArray;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link JsonArrayDeserializerTest}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class JsonArrayDeserializerTest {
+
+    private JsonArrayDeserializer deserializer;
+
+    @Mock
+    private JsonParser parser;
+
+    @Mock
+    private DeserializationContext context;
+
+    @Before
+    public void setUp() {
+        deserializer = new JsonArrayDeserializer();
+    }
+
+    @Test
+    public void testDeserializeEmptyArray() throws IOException {
+
+        when(parser.readValueAs(any(TypeReference.class))).thenReturn(new ArrayList<>());
+
+        JsonArray deserializedArray = deserializer.deserialize(parser, context);
+
+        assertNotNull(deserializedArray);
+        assertEquals(0, deserializedArray.size());
+
+    }
+
+    @Test
+    public void testDeserialize() throws IOException {
+
+        ArrayList<Object> results = new ArrayList<Object>();
+        results.add("first");
+        results.add("second");
+
+        when(parser.readValueAs(any(TypeReference.class))).thenReturn(results);
+
+        JsonArray deserializedArray = deserializer.deserialize(parser, context);
+
+        assertNotNull(deserializedArray);
+        assertEquals(2, deserializedArray.size());
+        assertEquals("first", deserializedArray.getString(0));
+        assertEquals("second", deserializedArray.getString(1));
+
+    }
+
+}

--- a/vertx-jersey-jackson/src/test/java/com/englishtown/vertx/jersey/jackson/internal/JsonArraySerializerTest.java
+++ b/vertx-jersey-jackson/src/test/java/com/englishtown/vertx/jersey/jackson/internal/JsonArraySerializerTest.java
@@ -1,0 +1,104 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.jackson.internal;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import io.vertx.core.json.JsonArray;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link JsonArraySerializer}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class JsonArraySerializerTest {
+
+    @Captor
+    private ArgumentCaptor<Object> valueCaptor;
+
+    @Mock
+    private JsonGenerator generator;
+
+    private JsonArraySerializer serializer;
+
+    @Before
+    public void setUp() {
+
+        serializer = new JsonArraySerializer();
+
+    }
+
+    @Test
+    public void testSerializeEmptyArray() throws IOException {
+
+        serializer.serialize(new JsonArray(), generator, null);
+
+        verify(generator).writeObject(valueCaptor.capture());
+
+        Object capturedObject = valueCaptor.getValue();
+
+        assertTrue(capturedObject instanceof List);
+        @SuppressWarnings("unchecked")
+        List<Object> capturedList = (List<Object>) capturedObject;
+
+        assertTrue(capturedList.isEmpty());
+
+    }
+
+    @Test
+    public void testSerialize() throws IOException {
+
+
+        JsonArray testArray = new JsonArray();
+        testArray.add("first");
+        testArray.add("second");
+
+        serializer.serialize(testArray, generator, null);
+
+        verify(generator).writeObject(valueCaptor.capture());
+
+        Object capturedObject = valueCaptor.getValue();
+
+        assertTrue(capturedObject instanceof List);
+        @SuppressWarnings("unchecked")
+        List<Object> capturedList = (List<Object>) capturedObject;
+
+        assertEquals(2, capturedList.size());
+        assertTrue(capturedList.contains("first"));
+        assertTrue(capturedList.contains("second"));
+
+    }
+
+}

--- a/vertx-jersey-jackson/src/test/java/com/englishtown/vertx/jersey/jackson/internal/JsonObjectDeserializerTest.java
+++ b/vertx-jersey-jackson/src/test/java/com/englishtown/vertx/jersey/jackson/internal/JsonObjectDeserializerTest.java
@@ -1,0 +1,94 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.jackson.internal;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import io.vertx.core.json.JsonObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link JsonObjectDeserializerTest}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class JsonObjectDeserializerTest {
+
+    private JsonObjectDeserializer deserializer;
+
+    @Mock
+    private JsonParser parser;
+
+    @Mock
+    private DeserializationContext context;
+
+    @Before
+    public void setUp() {
+        deserializer = new JsonObjectDeserializer();
+    }
+
+    @Test
+    public void testDeserializeEmptyObject() throws IOException {
+
+        when(parser.readValueAs(any(TypeReference.class))).thenReturn(new LinkedHashMap<>());
+
+        JsonObject deserializedObject = deserializer.deserialize(parser, context);
+
+        assertNotNull(deserializedObject);
+        assertEquals(0, deserializedObject.size());
+
+    }
+
+    @Test
+    public void testDeserialize() throws IOException {
+
+        Map<String, Object> results = new LinkedHashMap<>();
+        results.put("first", "1");
+        results.put("second", "2");
+
+        when(parser.readValueAs(any(TypeReference.class))).thenReturn(results);
+
+        JsonObject deserializedObject = deserializer.deserialize(parser, context);
+
+        assertNotNull(deserializedObject);
+        assertEquals(2, deserializedObject.size());
+        assertEquals("1", deserializedObject.getString("first"));
+        assertEquals("2", deserializedObject.getString("second"));
+
+    }
+
+}

--- a/vertx-jersey-jackson/src/test/java/com/englishtown/vertx/jersey/jackson/internal/JsonObjectSerializerTest.java
+++ b/vertx-jersey-jackson/src/test/java/com/englishtown/vertx/jersey/jackson/internal/JsonObjectSerializerTest.java
@@ -1,0 +1,105 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.jackson.internal;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import io.vertx.core.json.JsonObject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Tests for {@link JsonObjectSerializer}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class JsonObjectSerializerTest {
+
+    @Captor
+    private ArgumentCaptor<Object> valueCaptor;
+
+    @Mock
+    private JsonGenerator generator;
+
+    private JsonObjectSerializer serializer;
+
+    @Before
+    public void setUp() {
+
+        serializer = new JsonObjectSerializer();
+
+    }
+
+    @Test
+    public void testSerializeEmptyObject() throws IOException {
+
+        serializer.serialize(new JsonObject(), generator, null);
+
+        verify(generator).writeObject(valueCaptor.capture());
+
+        Object capturedObject = valueCaptor.getValue();
+
+        assertTrue(capturedObject instanceof Map);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> capturedMap = (Map<String, Object>) capturedObject;
+
+        assertTrue(capturedMap.isEmpty());
+
+    }
+
+    @Test
+    public void testSerialize() throws IOException {
+
+
+        JsonObject testArray = new JsonObject();
+        testArray.put("first", "1");
+        testArray.put("second", "2");
+
+        serializer.serialize(testArray, generator, null);
+
+        verify(generator).writeObject(valueCaptor.capture());
+
+        Object capturedObject = valueCaptor.getValue();
+
+        assertTrue(capturedObject instanceof Map);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> capturedMap = (Map<String, Object>) capturedObject;
+
+        assertEquals(2, capturedMap.size());
+        assertEquals("1", capturedMap.get("first"));
+        assertEquals("2", capturedMap.get("second"));
+
+    }
+
+}

--- a/vertx-jersey-jackson/src/test/java/com/englishtown/vertx/jersey/model/JsonArrayWrapper.java
+++ b/vertx-jersey-jackson/src/test/java/com/englishtown/vertx/jersey/model/JsonArrayWrapper.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.vertx.core.json.JsonArray;
+
+/**
+ * An object containing a JsonArray, for use in integration test REST endpoints testing serialization/deserialization
+ * of nested objects.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JsonArrayWrapper {
+
+    private JsonArray jsonArray;
+
+    public JsonArray getJsonArray() {
+        return jsonArray;
+    }
+
+    public void setJsonArray(JsonArray jsonArray) {
+        this.jsonArray = jsonArray;
+    }
+
+}

--- a/vertx-jersey-jackson/src/test/java/com/englishtown/vertx/jersey/model/JsonObjectWrapper.java
+++ b/vertx-jersey-jackson/src/test/java/com/englishtown/vertx/jersey/model/JsonObjectWrapper.java
@@ -1,0 +1,46 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * An object containing a JsonObject, for use in integration test REST endpoints testing serialization/deserialization
+ * of nested objects.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class JsonObjectWrapper {
+
+    private JsonObject jsonObject;
+
+    public JsonObject getJsonObject() {
+        return jsonObject;
+    }
+
+    public void setJsonObject(JsonObject jsonObject) {
+        this.jsonObject = jsonObject;
+    }
+
+}

--- a/vertx-jersey-jackson/src/test/java/com/englishtown/vertx/jersey/resources/TestResource.java
+++ b/vertx-jersey-jackson/src/test/java/com/englishtown/vertx/jersey/resources/TestResource.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.resources;
+
+import com.englishtown.vertx.jersey.model.JsonArrayWrapper;
+import com.englishtown.vertx.jersey.model.JsonObjectWrapper;
+
+import javax.ws.rs.*;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * A sample Jersey resource for integration testing.
+ */
+@Path("test")
+public class TestResource {
+
+    @Path("object")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonObjectWrapper postObject(JsonObjectWrapper object) {
+        return object;
+    }
+
+    @Path("array")
+    @POST
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public JsonArrayWrapper postArray(JsonArrayWrapper array) {
+        return array;
+    }
+
+}

--- a/vertx-jersey/src/main/java/com/englishtown/vertx/hk2/HK2JerseyBinder.java
+++ b/vertx-jersey/src/main/java/com/englishtown/vertx/hk2/HK2JerseyBinder.java
@@ -32,7 +32,9 @@ import com.englishtown.vertx.jersey.inject.ContainerResponseWriterProvider;
 import com.englishtown.vertx.jersey.inject.VertxPostResponseProcessor;
 import com.englishtown.vertx.jersey.inject.VertxRequestProcessor;
 import com.englishtown.vertx.jersey.inject.VertxResponseProcessor;
-import com.englishtown.vertx.jersey.inject.impl.VertxResponseWriterProvider;
+import com.englishtown.vertx.jersey.inject.impl.*;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import org.glassfish.hk2.api.Factory;
 import org.glassfish.hk2.api.IterableProvider;
 import org.glassfish.hk2.api.TypeLiteral;
@@ -40,6 +42,7 @@ import org.glassfish.hk2.utilities.binding.AbstractBinder;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import javax.ws.rs.ext.MessageBodyReader;
 import javax.ws.rs.ext.MessageBodyWriter;
 import java.util.ArrayList;
 import java.util.List;
@@ -142,6 +145,14 @@ public class HK2JerseyBinder extends AbstractBinder {
         bind(DefaultJerseyHandler.class).to(JerseyHandler.class);
         bind(DefaultJerseyOptions.class).to(JerseyOptions.class);
         bind(VertxResponseWriterProvider.class).to(ContainerResponseWriterProvider.class);
+        bind(JsonArrayReader.class).to(new TypeLiteral<MessageBodyReader<JsonArray>>() {
+        });
+        bind(JsonArrayWriter.class).to(new TypeLiteral<MessageBodyWriter<JsonArray>>() {
+        });
+        bind(JsonObjectReader.class).to(new TypeLiteral<MessageBodyReader<JsonObject>>() {
+        });
+        bind(JsonObjectWriter.class).to(new TypeLiteral<MessageBodyWriter<JsonObject>>() {
+        });
         bind(WriteStreamBodyWriter.class).to(MessageBodyWriter.class).in(Singleton.class);
 
         bindFactory(VertxRequestProcessorFactory.class).to(new TypeLiteral<List<VertxRequestProcessor>>() {

--- a/vertx-jersey/src/main/java/com/englishtown/vertx/jersey/inject/impl/JsonArrayReader.java
+++ b/vertx-jersey/src/main/java/com/englishtown/vertx/jersey/inject/impl/JsonArrayReader.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.inject.impl;
+
+import io.vertx.core.json.JsonArray;
+import org.glassfish.jersey.message.internal.ReaderWriter;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+/**
+ * A {@link MessageBodyReader} for deserializing Vertx JsonArrays.
+ */
+@Provider
+@Consumes(MediaType.APPLICATION_JSON)
+public class JsonArrayReader implements MessageBodyReader<JsonArray> {
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return type == JsonArray.class;
+    }
+
+    @Override
+    public JsonArray readFrom(Class<JsonArray> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
+
+        try {
+            return new JsonArray(
+                ReaderWriter.readFromAsString(entityStream, MediaType.APPLICATION_JSON_TYPE)
+            );
+        } catch (Exception e) {
+            throw new BadRequestException(e);
+        }
+
+    }
+
+}

--- a/vertx-jersey/src/main/java/com/englishtown/vertx/jersey/inject/impl/JsonArrayWriter.java
+++ b/vertx-jersey/src/main/java/com/englishtown/vertx/jersey/inject/impl/JsonArrayWriter.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.inject.impl;
+
+import io.vertx.core.json.JsonArray;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+/**
+ * A {@link MessageBodyWriter} for serializing Vertx JsonArrays.
+ */
+public class JsonArrayWriter implements MessageBodyWriter<JsonArray> {
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return type == JsonArray.class;
+    }
+
+    @Override
+    public long getSize(JsonArray entries, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        //Return -1 so size is automatically calculated (see parent javadoc)
+        return -1;
+    }
+
+    @Override
+    public void writeTo(JsonArray entries, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+        entityStream.write(entries.encode().getBytes());
+    }
+
+}

--- a/vertx-jersey/src/main/java/com/englishtown/vertx/jersey/inject/impl/JsonObjectReader.java
+++ b/vertx-jersey/src/main/java/com/englishtown/vertx/jersey/inject/impl/JsonObjectReader.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.inject.impl;
+
+import io.vertx.core.json.JsonObject;
+import org.glassfish.jersey.message.internal.ReaderWriter;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyReader;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+/**
+ * A {@link MessageBodyReader} for deserializing to Vertx JsonObjects.
+ */
+@Provider
+@Consumes(MediaType.APPLICATION_JSON)
+public class JsonObjectReader implements MessageBodyReader<JsonObject> {
+
+    @Override
+    public boolean isReadable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return type == JsonObject.class;
+    }
+
+    @Override
+    public JsonObject readFrom(Class<JsonObject> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, String> httpHeaders, InputStream entityStream) throws IOException, WebApplicationException {
+
+        try {
+            return new JsonObject(
+                ReaderWriter.readFromAsString(entityStream, MediaType.APPLICATION_JSON_TYPE)
+            );
+        } catch (Exception e) {
+            throw new BadRequestException(e);
+        }
+
+    }
+
+}

--- a/vertx-jersey/src/main/java/com/englishtown/vertx/jersey/inject/impl/JsonObjectWriter.java
+++ b/vertx-jersey/src/main/java/com/englishtown/vertx/jersey/inject/impl/JsonObjectWriter.java
@@ -1,0 +1,62 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.inject.impl;
+
+import io.vertx.core.json.JsonObject;
+
+import javax.ws.rs.Produces;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.MessageBodyWriter;
+import javax.ws.rs.ext.Provider;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+/**
+ * A {@link MessageBodyWriter} for serializing Vertx JsonObjects.
+ */
+@Provider
+@Produces(MediaType.APPLICATION_JSON)
+public class JsonObjectWriter implements MessageBodyWriter<JsonObject> {
+
+    @Override
+    public boolean isWriteable(Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        return type == JsonObject.class;
+    }
+
+    @Override
+    public long getSize(JsonObject entries, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType) {
+        //Return -1 so size is automatically calculated (see parent javadoc)
+        return -1;
+    }
+
+    @Override
+    public void writeTo(JsonObject entries, Class<?> type, Type genericType, Annotation[] annotations, MediaType mediaType, MultivaluedMap<String, Object> httpHeaders, OutputStream entityStream) throws IOException, WebApplicationException {
+        entityStream.write(entries.encode().getBytes());
+    }
+
+}

--- a/vertx-jersey/src/test/java/com/englishtown/vertx/jersey/inject/impl/JsonArrayReaderTest.java
+++ b/vertx-jersey/src/test/java/com/englishtown/vertx/jersey/inject/impl/JsonArrayReaderTest.java
@@ -1,0 +1,147 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.inject.impl;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+
+import static org.junit.Assert.*;
+
+/**
+ * {@link JsonArrayReader} tests.
+ */
+public class JsonArrayReaderTest {
+
+    private JsonArrayReader testReader;
+
+    private PipedInputStream inputStream;
+    private PipedOutputStream outputStream;
+
+    @Before
+    public void setUp() throws IOException {
+
+        testReader = new JsonArrayReader();
+
+        inputStream = new PipedInputStream();
+        outputStream = new PipedOutputStream(inputStream);
+
+    }
+
+    @After
+    public void tearDown() throws IOException {
+
+        outputStream.close();
+        inputStream.close();
+
+    }
+
+    @Test
+    public void test_isReadablePositive() {
+        assertTrue(testReader.isReadable(JsonArray.class, null, null, MediaType.APPLICATION_JSON_TYPE));
+    }
+
+    @Test
+    public void test_isReadableNegative() {
+        assertFalse(testReader.isReadable(JsonObject.class, null, null, MediaType.APPLICATION_JSON_TYPE));
+        assertFalse(testReader.isReadable(String.class, null, null, MediaType.APPLICATION_JSON_TYPE));
+    }
+
+    @Test
+    public void test_readFromEmpty() throws IOException {
+
+        outputStream.write("[]".getBytes());
+        outputStream.close();
+
+        JsonArray result = testReader.readFrom(JsonArray.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, inputStream);
+
+        assertNotNull(result);
+        assertEquals(0, result.size());
+
+    }
+
+    @Test
+    public void test_readFromSimple() throws IOException {
+
+        outputStream.write("[\"value\"]".getBytes());
+        outputStream.close();
+
+        JsonArray result = testReader.readFrom(JsonArray.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, inputStream);
+
+        assertNotNull(result);
+        assertEquals("value", result.getString(0));
+
+    }
+
+    @Test
+    public void test_readFromNestedArray() throws IOException {
+
+        outputStream.write("[[1, 2], [\"a\", \"b\", \"c\"]]".getBytes());
+        outputStream.close();
+
+        JsonArray result = testReader.readFrom(JsonArray.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, inputStream);
+
+        assertNotNull(result);
+        assertEquals(2, result.size());
+        JsonArray innerArray = result.getJsonArray(0);
+        assertEquals(2, innerArray.size());
+        innerArray = result.getJsonArray(1);
+        assertEquals(3, innerArray.size());
+
+    }
+
+    @Test
+    public void test_readFromNestedObject() throws IOException {
+
+        outputStream.write("[{\"key\": \"value\"}]".getBytes());
+        outputStream.close();
+
+        JsonArray result = testReader.readFrom(JsonArray.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, inputStream);
+
+        assertNotNull(result);
+        JsonObject innerObject = result.getJsonObject(0);
+        assertEquals("value", innerObject.getString("key"));
+
+    }
+
+    @Test(expected=BadRequestException.class)
+    public void test_readFromInvalidInput() throws IOException {
+
+        outputStream.write("[".getBytes());
+        outputStream.close();
+
+        //This should throw an exception
+        testReader.readFrom(JsonArray.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, inputStream);
+
+    }
+
+}

--- a/vertx-jersey/src/test/java/com/englishtown/vertx/jersey/inject/impl/JsonArrayWriterTest.java
+++ b/vertx-jersey/src/test/java/com/englishtown/vertx/jersey/inject/impl/JsonArrayWriterTest.java
@@ -1,0 +1,142 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.inject.impl;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.glassfish.jersey.message.internal.ReaderWriter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+
+import static org.junit.Assert.*;
+
+/**
+ * {@link JsonArrayWriter} tests.
+ */
+public class JsonArrayWriterTest {
+
+    private JsonArrayWriter testWriter;
+    private JsonArray testArray;
+
+    private PipedInputStream inputStream;
+    private PipedOutputStream outputStream;
+
+    @Before
+    public void setUp() throws IOException {
+
+        testWriter = new JsonArrayWriter();
+        testArray = new JsonArray();
+
+        inputStream = new PipedInputStream();
+        outputStream = new PipedOutputStream(inputStream);
+
+    }
+
+    @After
+    public void tearDown() throws IOException {
+
+        outputStream.close();
+        inputStream.close();
+
+    }
+
+    @Test
+    public void test_isReadablePositive() {
+        assertTrue(testWriter.isWriteable(JsonArray.class, null, null, MediaType.APPLICATION_JSON_TYPE));
+    }
+
+    @Test
+    public void test_isReadableNegative() {
+        assertFalse(testWriter.isWriteable(JsonObject.class, null, null, MediaType.APPLICATION_JSON_TYPE));
+        assertFalse(testWriter.isWriteable(String.class, null, null, MediaType.APPLICATION_JSON_TYPE));
+    }
+
+    @Test
+    public void test_getSize() {
+        //Should always return -1 to have the length be auto-calculated
+        assertEquals(-1, testWriter.getSize(null, null, null, null, null));
+    }
+
+    @Test
+    public void test_readFromEmpty() throws IOException {
+
+        testWriter.writeTo(testArray, JsonArray.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, outputStream);
+        outputStream.close();
+
+        assertEquals("[]", ReaderWriter.readFromAsString(inputStream, MediaType.APPLICATION_JSON_TYPE));
+
+    }
+
+    @Test
+    public void test_readFromSimple() throws IOException {
+
+        testArray.add("value");
+
+        testWriter.writeTo(testArray, JsonArray.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, outputStream);
+        outputStream.close();
+
+        assertEquals("[\"value\"]",
+                ReaderWriter.readFromAsString(inputStream, MediaType.APPLICATION_JSON_TYPE));
+
+    }
+
+    @Test
+    public void test_readFromNestedArray() throws IOException {
+
+        JsonArray innerArray = new JsonArray();
+        innerArray.add("one");
+        innerArray.add("two");
+        innerArray.add("three");
+        testArray.add(innerArray);
+
+        testWriter.writeTo(testArray, JsonArray.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, outputStream);
+        outputStream.close();
+
+        assertEquals("[[\"one\",\"two\",\"three\"]]",
+                ReaderWriter.readFromAsString(inputStream, MediaType.APPLICATION_JSON_TYPE));
+
+    }
+
+    @Test
+    public void test_readFromNestedObject() throws IOException {
+
+        JsonObject innerObject = new JsonObject();
+        innerObject.put("key", "value");
+        testArray.add(innerObject);
+
+        testWriter.writeTo(testArray, JsonArray.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, outputStream);
+        outputStream.close();
+
+        assertEquals("[{\"key\":\"value\"}]",
+                ReaderWriter.readFromAsString(inputStream, MediaType.APPLICATION_JSON_TYPE));
+
+    }
+
+}

--- a/vertx-jersey/src/test/java/com/englishtown/vertx/jersey/inject/impl/JsonObjectReaderTest.java
+++ b/vertx-jersey/src/test/java/com/englishtown/vertx/jersey/inject/impl/JsonObjectReaderTest.java
@@ -1,0 +1,145 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.inject.impl;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.BadRequestException;
+import javax.ws.rs.core.MediaType;
+
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+
+import static org.junit.Assert.*;
+
+/**
+ * {@link JsonObjectReader} tests.
+ */
+public class JsonObjectReaderTest {
+
+    private JsonObjectReader testReader;
+
+    private PipedInputStream inputStream;
+    private PipedOutputStream outputStream;
+
+    @Before
+    public void setUp() throws IOException {
+
+        testReader = new JsonObjectReader();
+
+        inputStream = new PipedInputStream();
+        outputStream = new PipedOutputStream(inputStream);
+
+    }
+
+    @After
+    public void tearDown() throws IOException {
+
+        outputStream.close();
+        inputStream.close();
+
+    }
+
+    @Test
+    public void test_isReadablePositive() {
+        assertTrue(testReader.isReadable(JsonObject.class, null, null, MediaType.APPLICATION_JSON_TYPE));
+    }
+
+    @Test
+    public void test_isReadableNegative() {
+        assertFalse(testReader.isReadable(JsonArray.class, null, null, MediaType.APPLICATION_JSON_TYPE));
+        assertFalse(testReader.isReadable(String.class, null, null, MediaType.APPLICATION_JSON_TYPE));
+    }
+
+    @Test
+    public void test_readFromEmpty() throws IOException {
+
+        outputStream.write("{}".getBytes());
+        outputStream.close();
+
+        JsonObject result = testReader.readFrom(JsonObject.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, inputStream);
+
+        assertNotNull(result);
+        assertEquals(0, result.size());
+
+    }
+
+    @Test
+    public void test_readFromSimple() throws IOException {
+
+        outputStream.write("{\"key\": \"value\"}".getBytes());
+        outputStream.close();
+
+        JsonObject result = testReader.readFrom(JsonObject.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, inputStream);
+
+        assertNotNull(result);
+        assertEquals("value", result.getString("key"));
+
+    }
+
+    @Test
+    public void test_readFromNestedArray() throws IOException {
+
+        outputStream.write("{\"keywords\": [\"one\", \"two\", \"three\"]}".getBytes());
+        outputStream.close();
+
+        JsonObject result = testReader.readFrom(JsonObject.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, inputStream);
+
+        assertNotNull(result);
+        JsonArray innerArray = result.getJsonArray("keywords");
+        assertEquals(3, innerArray.size());
+
+    }
+
+    @Test
+    public void test_readFromNestedObject() throws IOException {
+
+        outputStream.write("{\"inner\": {\"key\": \"value\"}}".getBytes());
+        outputStream.close();
+
+        JsonObject result = testReader.readFrom(JsonObject.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, inputStream);
+
+        assertNotNull(result);
+        JsonObject innerObject = result.getJsonObject("inner");
+        assertEquals("value", innerObject.getString("key"));
+
+    }
+
+    @Test(expected=BadRequestException.class)
+    public void test_readFromInvalidInput() throws IOException {
+
+        outputStream.write("{".getBytes());
+        outputStream.close();
+
+        //This should throw an exception
+        testReader.readFrom(JsonObject.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, inputStream);
+
+    }
+
+}

--- a/vertx-jersey/src/test/java/com/englishtown/vertx/jersey/inject/impl/JsonObjectWriterTest.java
+++ b/vertx-jersey/src/test/java/com/englishtown/vertx/jersey/inject/impl/JsonObjectWriterTest.java
@@ -1,0 +1,142 @@
+/*
+ * The MIT License (MIT)
+ * Copyright © 2013 Englishtown <opensource@englishtown.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the “Software”), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.englishtown.vertx.jersey.inject.impl;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.glassfish.jersey.message.internal.ReaderWriter;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.ws.rs.core.MediaType;
+import java.io.IOException;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+
+import static org.junit.Assert.*;
+
+/**
+ * {@link JsonObjectWriter} tests.
+ */
+public class JsonObjectWriterTest {
+
+    private JsonObjectWriter testWriter;
+    private JsonObject testObject;
+
+    private PipedInputStream inputStream;
+    private PipedOutputStream outputStream;
+
+    @Before
+    public void setUp() throws IOException {
+
+        testWriter = new JsonObjectWriter();
+        testObject = new JsonObject();
+
+        inputStream = new PipedInputStream();
+        outputStream = new PipedOutputStream(inputStream);
+
+    }
+
+    @After
+    public void tearDown() throws IOException {
+
+        outputStream.close();
+        inputStream.close();
+
+    }
+
+    @Test
+    public void test_isReadablePositive() {
+        assertTrue(testWriter.isWriteable(JsonObject.class, null, null, MediaType.APPLICATION_JSON_TYPE));
+    }
+
+    @Test
+    public void test_isReadableNegative() {
+        assertFalse(testWriter.isWriteable(JsonArray.class, null, null, MediaType.APPLICATION_JSON_TYPE));
+        assertFalse(testWriter.isWriteable(String.class, null, null, MediaType.APPLICATION_JSON_TYPE));
+    }
+
+    @Test
+    public void test_getSize() {
+        //Should always return -1 to have the length be auto-calculated
+        assertEquals(-1, testWriter.getSize(null, null, null, null, null));
+    }
+
+    @Test
+    public void test_readFromEmpty() throws IOException {
+
+        testWriter.writeTo(testObject, JsonObject.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, outputStream);
+        outputStream.close();
+
+        assertEquals("{}", ReaderWriter.readFromAsString(inputStream, MediaType.APPLICATION_JSON_TYPE));
+
+    }
+
+    @Test
+    public void test_readFromSimple() throws IOException {
+
+        testObject.put("key", "value");
+
+        testWriter.writeTo(testObject, JsonObject.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, outputStream);
+        outputStream.close();
+
+        assertEquals("{\"key\":\"value\"}",
+                ReaderWriter.readFromAsString(inputStream, MediaType.APPLICATION_JSON_TYPE));
+
+    }
+
+    @Test
+    public void test_readFromNestedArray() throws IOException {
+
+        JsonArray innerArray = new JsonArray();
+        innerArray.add("one");
+        innerArray.add("two");
+        innerArray.add("three");
+        testObject.put("keywords", innerArray);
+
+        testWriter.writeTo(testObject, JsonObject.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, outputStream);
+        outputStream.close();
+
+        assertEquals("{\"keywords\":[\"one\",\"two\",\"three\"]}",
+                ReaderWriter.readFromAsString(inputStream, MediaType.APPLICATION_JSON_TYPE));
+
+    }
+
+    @Test
+    public void test_readFromNestedObject() throws IOException {
+
+        JsonObject innerObject = new JsonObject();
+        innerObject.put("key", "value");
+        testObject.put("inner", innerObject);
+
+        testWriter.writeTo(testObject, JsonObject.class, null, null, MediaType.APPLICATION_JSON_TYPE, null, outputStream);
+        outputStream.close();
+
+        assertEquals("{\"inner\":{\"key\":\"value\"}}",
+                ReaderWriter.readFromAsString(inputStream, MediaType.APPLICATION_JSON_TYPE));
+
+    }
+
+}

--- a/vertx-jersey/src/test/java/com/englishtown/vertx/jersey/integration/IntegrationTests.java
+++ b/vertx-jersey/src/test/java/com/englishtown/vertx/jersey/integration/IntegrationTests.java
@@ -106,6 +106,32 @@ public class IntegrationTests extends JerseyHK2IntegrationTestBase {
     }
 
     @Test
+    public void test_postJsonArray() throws Exception {
+
+        HttpClientRequest request = httpClient.request(HttpMethod.POST, port, host, "/rest/test/jsonarray", response -> {
+            verifyResponse(response, 200, MediaType.APPLICATION_JSON, "[\"async response\"]");
+        });
+
+        request.headers().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        request.end("[\"post\"]");
+        await();
+
+    }
+
+    @Test
+    public void test_postJsonObject() throws Exception {
+
+        HttpClientRequest request = httpClient.request(HttpMethod.POST, port, host, "/rest/test/jsonobject", response -> {
+            verifyResponse(response, 200, MediaType.APPLICATION_JSON, "{\"name\":\"async response\"}");
+        });
+
+        request.headers().add(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+        request.end("{\"name\":\"post\"}");
+        await();
+
+    }
+
+    @Test
     public void test_getChunked() throws Exception {
 
         HttpClientRequest request = httpClient.request(HttpMethod.GET, port, host, "/rest/test/chunked", response -> {

--- a/vertx-jersey/src/test/java/com/englishtown/vertx/jersey/resources/TestResource.java
+++ b/vertx-jersey/src/test/java/com/englishtown/vertx/jersey/resources/TestResource.java
@@ -25,6 +25,8 @@ package com.englishtown.vertx.jersey.resources;
 
 import com.englishtown.vertx.jersey.integration.MyObject;
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import org.glassfish.jersey.server.ChunkedOutput;
 import org.glassfish.jersey.server.JSONP;
 
@@ -87,6 +89,46 @@ public class TestResource {
             obj2.setName("async response");
             response.resume(obj2);
         });
+    }
+
+    @POST
+    @Path("jsonarray")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public void postJsonArray(
+            final JsonArray jsonArr,
+            @Suspended final AsyncResponse response,
+            @Context Vertx vertx) {
+
+        vertx.runOnContext((aVoid) -> {
+            if (jsonArr == null) {
+                throw new RuntimeException();
+            }
+            JsonArray jsonArr2 = new JsonArray();
+            jsonArr2.add("async response");
+            response.resume(jsonArr2);
+        });
+
+    }
+
+    @POST
+    @Path("jsonobject")
+    @Consumes(MediaType.APPLICATION_JSON)
+    @Produces(MediaType.APPLICATION_JSON)
+    public void postJsonObject(
+            final JsonObject jsonObj,
+            @Suspended final AsyncResponse response,
+            @Context Vertx vertx) {
+
+        vertx.runOnContext((aVoid) -> {
+            if (jsonObj == null) {
+                throw new RuntimeException();
+            }
+            JsonObject jsonObj2 = new JsonObject();
+            jsonObj2.put("name", "async response");
+            response.resume(jsonObj2);
+        });
+
     }
 
     @GET


### PR DESCRIPTION
Includes `MessageBodyReader`s and `MessageBodyWriter`s to allow JsonObjects and JsonArrays to be used directly, for example: `@POST @Consumes(MediaType.APPLICATION_JSON) public void doSomething(JsonObject obj)`

Also includes custom serializers and deserializers for Jackson in a separate module to allow POJO parameters with JsonObject and JsonArray fields, for example:

```java
//POJO class:
public class User {
    private JsonObject fields;
    public JsonObject getFields() { return fields; }
    public void setFields(JsonObject fields) { this.fields = fields; }
}

//And in the resource:
@POST
@Consumes(MediaType.APPLICATION_JSON)
public void doSomething(User user) {
  //...
}
```

Finally, includes some examples in the example module demonstrating the use of POJOs as REST endpoint parameters.