### PR TITLE
Include all values for a particular header into the response.

### DIFF
--- a/vertx-jersey/src/main/java/com/englishtown/vertx/jersey/impl/VertxResponseWriter.java
+++ b/vertx-jersey/src/main/java/com/englishtown/vertx/jersey/impl/VertxResponseWriter.java
@@ -260,9 +260,7 @@ public class VertxResponseWriter implements ContainerResponseWriter {
         }
 
         for (final Map.Entry<String, List<String>> e : responseContext.getStringHeaders().entrySet()) {
-            for (final String value : e.getValue()) {
-                response.putHeader(e.getKey(), value);
-            }
+            response.putHeader(e.getKey(), e.getValue());            
         }
 
         // Run any response processors

--- a/vertx-jersey/src/test/java/com/englishtown/vertx/jersey/impl/VertxResponseWriterTest.java
+++ b/vertx-jersey/src/test/java/com/englishtown/vertx/jersey/impl/VertxResponseWriterTest.java
@@ -107,12 +107,12 @@ public class VertxResponseWriterTest {
         assertNotNull(outputStream);
         verify(response, times(1)).setStatusCode(anyInt());
         verify(response, times(1)).setStatusMessage(anyString());
-        verify(response, times(2)).putHeader(anyString(), anyString());
+        verify(response, times(1)).putHeader(anyString(), anyListOf(String.class));
         verify(processor1).process(eq(response), eq(cr));
         verify(processor2).process(eq(response), eq(cr));
 
         writer.writeResponseStatusAndHeaders(-1, cr);
-        verify(response, times(3)).putHeader(anyString(), anyString());
+        verify(response, times(2)).putHeader(anyString(), anyListOf(String.class));
 
     }
 
@@ -135,12 +135,12 @@ public class VertxResponseWriterTest {
         assertNotNull(outputStream);
         verify(response, times(1)).setStatusCode(anyInt());
         verify(response, times(1)).setStatusMessage(anyString());
-        verify(response, times(2)).putHeader(anyString(), anyString());
+        verify(response, times(1)).putHeader(anyString(), anyListOf(String.class));
         verify(processor1).process(eq(response), eq(cr));
         verify(processor2).process(eq(response), eq(cr));
 
         writer.writeResponseStatusAndHeaders(-1, cr);
-        verify(response, times(3)).putHeader(anyString(), anyString());
+        verify(response, times(2)).putHeader(anyString(), anyListOf(String.class));
 
     }
 


### PR DESCRIPTION
The previous implementation looped around calling the putHeader method that accepts a singular value.  

For a multi-valued header this resulted in the last value in the list overwriting any previously set header value(s).  i.e. If a resource returned 3 links in the Link header only the last link would be returned by vertx-jersey.